### PR TITLE
Issue #36 対応: Port forward コマンドへの profile 引数追加、langfuse README.md の port forward 引数追加

### DIFF
--- a/workshops/ai-coding-workshop/cline/0.setup/1.cline/README.md
+++ b/workshops/ai-coding-workshop/cline/0.setup/1.cline/README.md
@@ -31,7 +31,7 @@ aws configure
 設定後、`~/.aws/credentials` ファイルは以下のようになります：
 
 ```
-[Cline]
+[cline]
 aws_access_key_id = AKIAXXXXXXXXXXXXXXXX
 aws_secret_access_key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 region = us-east-1
@@ -55,7 +55,7 @@ aws configure sso
 設定後、`~/.aws/config` ファイルは以下のようになります：
 
 ```
-[profile Cline]
+[profile cline]
 sso_session = sso-session-name
 sso_account_id = 123456789012
 sso_role_name = RoleName
@@ -73,7 +73,7 @@ sso_registration_scopes = sso:account:access
 
 以下の設定項目を正確に入力してください：
 
-- AWS Profile Name: Cline
+- AWS Profile Name: cline
   - credentials ファイルで設定したプロファイル名と一致させてください
 - AWS Region: us-east-1
   - Bedrock のサービスが利用可能なリージョンを指定

--- a/workshops/ai-coding-workshop/cline/4.langfuse/README.md
+++ b/workshops/ai-coding-workshop/cline/4.langfuse/README.md
@@ -99,8 +99,10 @@ graph TB
 
 3. 動作確認
    ```bash
-   # ポートフォワーディングの設定 (Local PC で実行してください)
-   ../scripts/port_forward.py
+   # ポートフォワーディングの設定
+   # ローカル PC で実行してください。
+   # インスタンス ID を環境変数、引数 -i、config.yml いずれかで設定してください。
+   uv run ../scripts/port_forward.py --instance-id i-xxx --profile cline
    
    # ブラウザで Langfuse Web UI にアクセス
    # http://localhost:3000


### PR DESCRIPTION
https://github.com/littlemex/aws-samples/issues/36 の対応

- [x] scripts/port_forward.py に profile 引数を追加
- [x] Cline, cline で profile 名に揺れがあったので cline で統一
- [x] 4.langfuse/README.md の port_forward.py の引数が不足しているので追加